### PR TITLE
Perfmode on SL3 (Intel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you have a Surface Book 2 you might also want to have a look at the [dtx-daem
 | Surface Book 2         | lid status, battery status, clipboard detach events, performance-modes | -                                                                       |
 | Surface Laptop         | battery status, keyboard                                               | caps-lock indicator (#8), performance-modes (#18)                       |
 | Surface Laptop 2       | battery status, keyboard                                               | caps-lock indicator (#8), performance-modes (#18)                       |
-| Surface Laptop 3 (13") | battery status, keyboard                                               | performance-modes (#18)                                                 |
+| Surface Laptop 3 (13") | battery status, keyboard, performance-modes                            | -                                                                       |
 | Surface Laptop 3 (15") | battery status, keyboard                                               | performance-modes (#18)                                                 |
 | Surface Pro 2017       | battery status                                                         | keyboard backlight enabled during suspend (#4), performance-modes (#18) |
 | Surface Pro 6          | battery status                                                         | keyboard backlight enabled during suspend (#4), performance-modes (#18) |

--- a/module/surface_sam_sid.c
+++ b/module/surface_sam_sid.c
@@ -48,6 +48,7 @@ static const struct mfd_cell sid_devs_sl3_13[] = {
 	{ .name = "surface_sam_sid_vhf",     .id = -1 },
 	{ .name = "surface_sam_sid_ac",      .id = -1 },
 	{ .name = "surface_sam_sid_battery", .id = -1 },
+	{ .name = "surface_sam_sid_perfmode", .id = -1 },
 	{ },
 };
 


### PR DESCRIPTION
I checked the initial value and it was indeed 1. Setting it to 2/3/4 I could also properly retrieve the updated value.

It _feels_  like it's working but it's hard to tell since SL3 doesn't have an integrated graphics card or anything. I'm hoping that setting the value to 4 will stop my computer completely freezing up from overheating when doing compile heavy workloads.

Also, note that the instructions in the README are outdated,

```bash
echo <mode> | sudo tee /sys/devices/platform/MSHW0107:00/perf_mode
```

is now something like:

```bash
echo <mode> | sudo tee /sys/devices/platform/MSHW0107:00/surface_sam_sid_perfmode/perf_mode
```

(and also the MSHW model is different on the SL3)

Could we simplify that to:

```bash
echo <mode> | sudo tee /sys/bus/platform/devices/surface_sam_sid_perfmode/perf_mode
```