### PR TITLE
IRPMon log conversion fixes / overhaul

### DIFF
--- a/scripts/irpmon/irpmon_to_json.py
+++ b/scripts/irpmon/irpmon_to_json.py
@@ -486,7 +486,10 @@ def parse_json_file(path):
         bytedata = [a for a in codecs.decode(data, 'hex_codec')]
 
         irp_id = int(entry.get("ID"))
-        function = Function[entry.get("Major function")]
+        major_fun = entry.get("Major function")
+        if major_fun is None:
+            continue
+        function = Function[major_fun]
         curtime = entry.get("Time")
         status_constant = Status[entry.get("IOSB.Status constant")]
         irp_address =  int(entry.get("IRP address"), 0)

--- a/scripts/irpmon/irpmon_to_json.py
+++ b/scripts/irpmon/irpmon_to_json.py
@@ -4,7 +4,11 @@ import sys
 import codecs
 import json
 import time
+import gzip
+from collections import namedtuple
+from enum import Enum
 
+TARGET_DRIVER = "\Driver\iaLPSS2_UART2_ADL"
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
@@ -18,7 +22,7 @@ def data_push(delta):
 
 def data_timestamp(timestamps):
     global data_idx
-    prev = None
+    prev = timestamps[0][0]
     for ts, idx in timestamps:
         if idx > data_idx:
             return prev
@@ -74,48 +78,18 @@ class FrameCmd:
         }
 
 
-def parse_file(file):
-    function = 'NONE'
-    data = False
-    lines = []
-    cmddata = []
-    curtime = None
-    timestamps = []
-
-    for line in file:
-        if line.startswith("Major function ="):
-            function = line.split('=', 1)[1].strip()
-        elif line.startswith("Time = "):
-            curtime = line.split('=', 1)[1].strip()
-            # curtime = time.strptime(curtime, '%m/%d/%Y %I:%M:%S %p')
-        elif line.startswith("Data (Hexer)"):
-            data = True
-        elif data and line.startswith("  ") and line.strip():
-            lines.append(line.strip())
-        elif data:
-            if function == 'Read' or function == 'Write':
-                for l in lines:
-                    strdata = l.split("\t")[1]
-                    bytedata = [int(x, 16) for x in strdata.split()]
-                    timestamps.append((curtime, len(cmddata)))
-                    cmddata += bytedata
-
-            data = False
-            lines = []
-
-    timestamps.append((None, len(cmddata)))
-    return bytes(cmddata), timestamps
+def drop_until_syn(data):
+    for i in range(1, len(data)):
+        if data[i] == 0xaa and data[i+1] == 0x55:
+            eprint("data dropped: " + ' '.join(map(hex, data[:i])))
+            data_push(i+2)
+            return data[i+2:]
 
 
 def parse_syn(data):
     if data[0:2] != bytes([0xaa, 0x55]):
         eprint("warning: expected SYN, skipping data until next SYN")
-
-        for i in range(1, len(data)):
-            if data[i] == 0xaa and data[i+1] == 0x55:
-                eprint("data dropped: " + ' '.join(map(hex, data[:i])))
-                data_push(i+2)
-                return data[i+2:]
+        drop_until_syn(data)
 
     data_push(2)
     return data[2:]
@@ -123,9 +97,8 @@ def parse_syn(data):
 
 def parse_ter(data):
     if data[0:2] != bytes([0xff, 0xff]):
-        print("error: expected TER")
-        print(data)
-        exit(1)
+        eprint("warning: expected TER, skipping data until next SYN")
+        drop_until_syn(data)
 
     data_push(2)
     return data[2:]
@@ -191,12 +164,202 @@ def parse_commands(data, timestamps):
 
     return records
 
+def process_records(records):
+    all_data = bytearray([])
+    timestamps = []
+
+    # for r in records:
+        # print(r)
+
+    for record in records:
+        if not record.function in (Function.Read, Function.Write):
+            continue
+        # if not record.status in (Status.STATUS_SUCCESS, Status.STATUS_PENDING):
+            # continue
+        # Ok, data is good, add it.
+        all_data.extend(record.data)
+        timestamps.append((record.time, len(all_data)))
+
+    timestamps.append((None, len(all_data)))
+
+    # print(list(all_data))
+    return bytes(all_data), timestamps
+
+
+# Helper to hold the relevant fields from the log records.
+Irp = namedtuple("Irp", [
+    "id",
+    "function",
+    "time",
+    "status",
+    "address",
+    "data",
+])
+
+Function = Enum('Function', [
+    'Read',
+    'Write',
+    'PnP',
+    'Create',
+    'Cleanup',
+    'Close',
+    'DeviceControl',
+    'SystemControl',
+    'Power',
+    ])
+
+
+Status = Enum('Status', [
+    'STATUS_SUCCESS',
+    'STATUS_NOT_SUPPORTED',
+    'STATUS_PENDING',
+    'STATUS_CANCELLED',
+    'STATUS_TIMEOUT'])
+
+
+"""
+    Parse the log file, returning a list of records that pertain to the 
+    target driver.
+"""
+def parse_log_file(file):
+    major_function = 'NONE'
+    irp_id = None
+    irp_address = None
+    curtime = None
+    status = None
+    address = None
+
+    data = False
+    lines = []
+    discard = False
+
+    records = []
+
+    for line_nr, line in enumerate(file):
+        if line.startswith("ID ="):
+            irp_id = int(line.split('=', 1)[1].strip())
+        elif line.startswith("Major function ="):
+            function = Function[line.split('=', 1)[1].strip()]
+        elif line.startswith("IRP address ="):
+            irp_address = int(line.split('=', 1)[1].strip(), 0)
+        elif line.startswith("Driver name = "):
+            discard = line.split('=', 1)[1].strip() != TARGET_DRIVER
+        elif line.startswith("Time = "):
+            curtime = line.split('=', 1)[1].strip()
+            # curtime = time.strptime(curtime, '%m/%d/%Y %I:%M:%S %p')
+        elif line.startswith("IOSB.Status constant"):
+            status_constant = Status[line.split('=', 1)[1].strip()]
+        elif line.startswith("Data (Hexer)"):
+            data = True
+        elif data and line.startswith("  ") and line.strip():
+            lines.append(line.strip())
+        elif data:
+            bytedata = []
+            for l in lines:
+                strdata = l.split("\t")[1]
+                bytedata.extend([int(x, 16) for x in strdata.split()])
+
+            if not discard:
+                record = Irp(
+                    id = irp_id,
+                    function = function,
+                    time = curtime,
+                    status = status_constant,
+                    address = irp_address,
+                    data = bytedata)
+                records.append(record)
+
+
+            data = False
+            discard = False
+            lines = []
+
+    return records
+
+"""
+    Parse the json file, returning a list of records that pertain to the 
+    target driver.
+"""
+def parse_json_file(path):
+    opener = gzip.open if path.endswith("gz") else open
+
+    # This isn't compliant json, the 'stack' parameter is formatting is broken.
+    with opener(path, "rt") as f:
+        file_text = f.read()
+
+    # Patch the stack parameters
+    """
+    <...> denotes snip of repeating patterns
+        "Stack" : [{"Address" : 0x00007FFEBD5AF874, ), ,  <...>  {"Address" : 0x00007FFEBD56AA65, ), ]},
+    """
+    fixed_string = ""
+    # Check for the bad syntax first, future proofing if this gets fixed.
+    if ", ), ," in file_text:
+        # So we strip from '"Stack" : [' to the first `]`
+        # We can use string indexing and avoid regular expressions for speed.
+        current_index = 0
+        left_pattern = ', "Stack" : ['
+        right_pattern = ']'
+        while current_index != -1:
+            # Find until the next broken section
+            left_index = file_text.find(left_pattern, current_index)
+            fixed_string += file_text[current_index:left_index]
+            if left_index == -1:
+                # No more tokens, add the closing bracket.
+                fixed_string += file_text[-1]
+                break;
+            # Skip over the broken part.
+            right_index = file_text.find(right_pattern, left_index)
+            current_index = right_index + 1
+    else:
+        fixed_string = file_text
+
+    # Lets also add some newlines, in case we need to open the file.
+    fixed_string = fixed_string.replace('},{"ID"', '},\n{"ID"');
+
+    
+    #with open("/tmp/fixed.json", "w") as f:
+    #    f.write(fixed_string)
+
+    irp_entries = json.loads(fixed_string)
+
+    records = []
+    # Now we have good and clean data.
+    for entry in irp_entries:
+        if entry.get("Driver name") != TARGET_DRIVER:
+            continue
+        data = entry.get("Parsers", {}).get("Hexer", {}).get("Data0", '')
+        bytedata = [a for a in codecs.decode(data, 'hex_codec')]
+
+        irp_id = int(entry.get("ID"))
+        function = Function[entry.get("Major function")]
+        curtime = entry.get("Time")
+        status_constant = Status[entry.get("IOSB.Status constant")]
+        irp_address =  int(entry.get("IRP address"), 0)
+        record = Irp(
+            id = irp_id,
+            function = function,
+            time = curtime,
+            status = status_constant,
+            address = irp_address,
+            data = bytedata)
+        records.append(record)
+    return records
 
 def main(in_file):
-    with codecs.open(in_file, 'r', encoding='utf-8', errors='ignore') as fd:
-        data, timestamps = parse_file(fd)
+    if in_file.endswith("json") or in_file.endswith("json.gz"):
+        records = parse_json_file(in_file)
+    else:
+        opener = gzip.open if in_file.endswith("gz") else open
+        with opener(in_file, "rb") as f:
+            records = parse_log_file(codecs.iterdecode(f, encoding='utf-8', errors='ignore'))
 
-    print(json.dumps(parse_commands(data, timestamps)))
+    data, timestamps = process_records(records)
+
+    json_string = json.dumps(parse_commands(data, timestamps))
+    # This is safe as bytes are represented with integers.
+    json_string = json_string.replace("}, {", "},\n{")
+    print(json_string)
 
 
 if __name__ == '__main__':

--- a/scripts/irpmon/irpmon_to_json.py
+++ b/scripts/irpmon/irpmon_to_json.py
@@ -328,6 +328,8 @@ class BidirectionalParser:
         combined = self.read.communication()
         combined.extend(self.write.communication())
 
+        # Irp ids wrap, so sort it by index, which is the order in which the
+        # irp entries occured in the original log file.
         combined.sort(key=lambda x: x[1].index)
 
         # Now we no longer need the irp relations.

--- a/scripts/irpmon/irpmon_to_json.py
+++ b/scripts/irpmon/irpmon_to_json.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+
+# SPDX-License-Identifier: GPL-2.0+
+
 from __future__ import print_function
 import sys
 import codecs

--- a/scripts/irpmon/irpmon_to_json.py
+++ b/scripts/irpmon/irpmon_to_json.py
@@ -328,6 +328,11 @@ def parse_json_file(path):
     for entry in irp_entries:
         if entry.get("Driver name") != TARGET_DRIVER:
             continue
+
+        if entry.get("Type") != "IRP":
+            # "DriverDetected"
+            continue
+
         data = entry.get("Parsers", {}).get("Hexer", {}).get("Data0", '')
         bytedata = [a for a in codecs.decode(data, 'hex_codec')]
 


### PR DESCRIPTION
As mentioned in https://github.com/linux-surface/kernel/pull/144 I was running into some parsing problems with my newly obtained logs that contained the boot procedure.

This PR fixes the parsing problems, as well as introducing some other improvements:

- I tried using the new `.json` output from the latest IRPMon, unfortunately, it's not conformant json, so it needs a bit of munging.
- I added support for reading `.gz` files, since these logs compress to roughly 5% of the original.
- Made a clear 'parsing' for both log and json, that outputs `Irp` namedtuples.
- I overhauled the whole 'cmdbytes' approach and parsing architecture, instead of combining all data into a single byte array, we operate on the individual `Irp` records and advance through those, this allows printing helpful error messages that can be related to the original logged requests
- Fixed the main issue that broke the parsing; Writes can be interleaved with Read operations. See extensive comment in the script that shows an example of this, this is mitigated by parsing the Read and Write operations independently and then recombining them into a single output list, ordered by their occurance in the original log.
- Output is almost completely identical to the original script, the only thing that changes its the timestamps, I'm not 100% sure why this is the case, but the new approach uses the timestamp of the logged IRP that was the start of the command, so I'm fine with timestamps changing slightly from the historic output.
- Filter only on the relevant driver and discard some IRP records that occur during boot.
- Provide information about the log record whenever a SYN / TER isn't found.
- All boot logs I made a few days ago parse without any errors.
- I can understand if this overhaul is deemed to drastic, no problem.
