### PR TITLE
Allow overriding kdir.

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -4,8 +4,12 @@
 MODULE_NAME := "surface_aggregator_module"
 MODULE_VERSION := "0.1"
 
+# Allow overriding KDIR from an environment variable.
+ifeq ($(KDIR),)
 KVERSION := "$(shell uname -r)"
 KDIR := /lib/modules/$(KVERSION)/build
+endif
+
 MDIR := /usr/src/$(MODULE_NAME)-$(MODULE_VERSION)
 
 CHECKPATCH_OPTS := -f -q --no-tree --ignore LONG_LINE


### PR DESCRIPTION
Tiny tiny PR to make it trivial to build from this directory for anyone on NixOS.

On NixOS the kernel directory isn't in `/lib/modules`, but instead it is _somewhere_ in the Nix store, this allows multiple full kernel builds with the same version to exist on the system. It can be retrieved from the `<os configuration flake>#nixosConfigurations.<hostname>.config.boot.kernelPackages.kernel.dev` attribute.

Either way, this PR makes it such that `KDIR` can be set as an environment variable, if it is not set it uses `/lib/modules/`.